### PR TITLE
email typos

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -41,7 +41,7 @@ authors:
     name: Dylan Haynes
     initials: DRH
     orcid: 0000-0001-8986-8196
-    email: haynedy@ohsu.edu
+    email: dylan.haynes@pennmedicine.upenn.edu
     affiliations:
       - School of Medicine, Oregon Health & Science University
   - github: bluegenes
@@ -103,7 +103,7 @@ authors:
     initials: BDS
     orcid: 0000-0001-7720-6208
     twitter: BlairDSullivan
-    email: sulivan@cs.utah.edu
+    email: sullivan@cs.utah.edu
     affiliations:
       - School of Computing, University of Utah
     funders:


### PR DESCRIPTION
two emails had typos; one expired, the other was missing a letter